### PR TITLE
🥅 Return error if Query.First not found object

### DIFF
--- a/leancloud/query.go
+++ b/leancloud/query.go
@@ -2,6 +2,7 @@ package leancloud
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -316,16 +317,21 @@ func objectQuery(query interface{}, objects interface{}, count bool, first bool,
 	switch query.(type) {
 	case *Query:
 		decodedObjects, err := decodeArray(results, true)
+
 		if err != nil {
 			return nil, err
 		}
 
+		rDecodedObjects := reflect.ValueOf(decodedObjects)
+
 		if !first {
-			if err := bind(reflect.ValueOf(decodedObjects), reflect.ValueOf(objects).Elem()); err != nil {
+			if err := bind(rDecodedObjects, reflect.ValueOf(objects).Elem()); err != nil {
 				return nil, err
 			}
+		} else if rDecodedObjects.Len() == 0 {
+			return nil, errors.New("no matched object found")
 		} else {
-			if err := bind(reflect.ValueOf(decodedObjects).Index(0), reflect.ValueOf(objects).Elem()); err != nil {
+			if err := bind(rDecodedObjects.Index(0), reflect.ValueOf(objects).Elem()); err != nil {
 				return nil, err
 			}
 		}


### PR DESCRIPTION
修复了查询结果为空时 panic 的问题（`reflect: slice index out of range`）

现在查询结果为空时，会保持 object 不变（通常是零值）并返回一个错误（`no matched object found`）。

https://xindong.slack.com/archives/C01HZ8BS7PT/p1635233942039100